### PR TITLE
Don't default to x86, allow ARM target support

### DIFF
--- a/cmake/CompileDefinitions.cmake
+++ b/cmake/CompileDefinitions.cmake
@@ -1,26 +1,24 @@
-IF(WIN32) 
-	# platform defines for Windows 32bit Systems
+IF(WIN32)
+        # platform defines for Windows 32bit Systems
 	# define math constants like M_PI on Windows
 	ADD_DEFINITIONS(-D_USE_MATH_DEFINES)
-ELSEIF(APPLE) 
+ELSEIF(APPLE)
 	# platform defines for Mac OS X Systems
 	IF(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 		ADD_DEFINITIONS(-DPOSIX -DAPPLE -D__APPLE__)
 	ENDIF(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-ELSE(WIN32)	
+ELSE(WIN32)
 	# assumes linux/UNIX # platform defines for Linux Systems
 	ADD_DEFINITIONS(-DPOSIX -DLINUX -D__LINUX__)
 ENDIF(WIN32)
 ADD_DEFINITIONS( -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE )
 #define the architecture
 IF( ${CMAKE_BUILD_TYPE} STREQUAL "ATOM" )
- ADD_DEFINITIONS(-D ARCH_x86)
-ELSE()
-	IF("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64" OR APPLE )
-	 ADD_DEFINITIONS(-D ARCH_x86_64)
-	ELSE()
-	 ADD_DEFINITIONS(-D ARCH_x86)
-	ENDIF() 
+    ADD_DEFINITIONS(-DARCH_x86)
+ELSEIF(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" OR APPLE)
+    ADD_DEFINITIONS(-DARCH_x86_64)
+ELSEif(MAKE_SYSTEM_PROCESSOR STREQUAL "i686")
+    ADD_DEFINITIONS(-DARCH_x86)
 ENDIF()
 
 # add global definitions (all platforms, all compilers, all sources)


### PR DESCRIPTION
Only set the preprocessor definition for x86 and x86_64 if CMake says the processor architecture is actually present. Looks like a larger change than it is due to the CR/LR removal.

@jmtatsch: Can check if compiling on your ARM host works now?